### PR TITLE
feat: add firebase services and rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ VITE_FIREBASE_PROJECT_ID=your_project_id
 VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
+VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,24 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Turnos collection
+    match /turnos/{document} {
+      allow read, write: if request.auth != null;
+    }
+
+    // Product sales collection
+    match /productSales/{document} {
+      allow read, write: if request.auth != null;
+    }
+
+    // Users collection
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Deny access by default
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/scripts/removeCompletado.js
+++ b/scripts/removeCompletado.js
@@ -1,7 +1,7 @@
-import { getAllTurnos, updateTurno } from '../src/services/dataService.js';
+import { getAllTurnos, updateTurno } from '../src/services/turnoService.js';
 
 async function removeCompletado() {
-  const turnos = getAllTurnos();
+  const turnos = await getAllTurnos();
   const updates = turnos.map(t => updateTurno(t.id, { completado: undefined }));
   await Promise.all(updates);
   console.log('Propiedad "completado" eliminada de todos los turnos.');

--- a/src/pages/AddProducto.jsx
+++ b/src/pages/AddProducto.jsx
@@ -1,7 +1,7 @@
 // src/pages/AddProducto.jsx
 
 import React, { useState } from 'react';
-import { addProductSale } from '../services/dataService';
+import { addProductSale } from '../services/ventaService';
 import { serverTimestamp } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -1,7 +1,7 @@
 // src/pages/AddTurno.jsx
 
 import React, { useState } from 'react';
-import { addTurno, findTurnoByDate } from '../services/dataService';
+import { addTurno, findTurnoByDate } from '../services/turnoService';
 import { serverTimestamp } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -1,7 +1,7 @@
 // src/pages/EditTurno.jsx
 
 import React, { useState, useEffect } from 'react';
-import { getTurno, updateTurno, findTurnoByDate } from '../services/dataService';
+import { getTurno, updateTurno, findTurnoByDate } from '../services/turnoService';
 import { useParams, useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -1,7 +1,8 @@
 // src/pages/Finances.jsx
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { subscribeTurnos, subscribeProductSales } from '../services/dataService';
+import { subscribeTurnos } from '../services/turnoService';
+import { subscribeProductSales } from '../services/ventaService';
 import { formatCurrency } from '../utils/formatCurrency';
 
 function parseYearMonth(fecha) {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,7 @@
 // src/pages/Home.jsx
 
 import React, { useEffect, useState, useMemo } from "react";
-import { subscribeTurnos, deleteTurno } from "../services/dataService";
+import { subscribeTurnos, deleteTurno } from "../services/turnoService";
 import { useNavigate } from "react-router-dom";
 import CalendarView from "../components/CalendarView";
 import TurnoList from "../components/TurnoList";

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -10,6 +10,7 @@ const firebaseConfig = {
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
 // Initialize Firebase

--- a/src/services/turnoService.js
+++ b/src/services/turnoService.js
@@ -13,7 +13,6 @@ import {
 import { db } from './firebase';
 
 const TURNOS_COLLECTION = 'turnos';
-const PRODUCT_SALES_COLLECTION = 'productSales';
 
 // Subscribe to turnos collection
 export function subscribeTurnos(callback) {
@@ -56,22 +55,6 @@ export async function findTurnoByDate(fecha, hora) {
   );
   const snapshot = await getDocs(q);
   return snapshot.docs.length ? { id: snapshot.docs[0].id, ...snapshot.docs[0].data() } : null;
-}
-
-// Subscribe to product sales collection
-export function subscribeProductSales(callback) {
-  const colRef = collection(db, PRODUCT_SALES_COLLECTION);
-  const unsubscribe = onSnapshot(colRef, (snapshot) => {
-    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
-    callback(data);
-  });
-  return unsubscribe;
-}
-
-// Add a product sale record
-export async function addProductSale(sale) {
-  const docRef = await addDoc(collection(db, PRODUCT_SALES_COLLECTION), sale);
-  return { id: docRef.id, ...sale };
 }
 
 // Retrieve all turnos once

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,51 @@
+import {
+  collection,
+  addDoc,
+  doc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs,
+  onSnapshot,
+} from 'firebase/firestore';
+import { db } from './firebase';
+
+const USERS_COLLECTION = 'users';
+
+// Subscribe to users collection
+export function subscribeUsers(callback) {
+  const colRef = collection(db, USERS_COLLECTION);
+  const unsubscribe = onSnapshot(colRef, (snapshot) => {
+    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    callback(data);
+  });
+  return unsubscribe;
+}
+
+// Add a new user document
+export async function addUser(user) {
+  const docRef = await addDoc(collection(db, USERS_COLLECTION), user);
+  return { id: docRef.id, ...user };
+}
+
+// Get a user by id
+export async function getUser(id) {
+  const snap = await getDoc(doc(db, USERS_COLLECTION, id));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+// Update a user document
+export function updateUser(id, data) {
+  return updateDoc(doc(db, USERS_COLLECTION, id), data);
+}
+
+// Delete a user document
+export function deleteUser(id) {
+  return deleteDoc(doc(db, USERS_COLLECTION, id));
+}
+
+// Retrieve all users once
+export async function getAllUsers() {
+  const snapshot = await getDocs(collection(db, USERS_COLLECTION));
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+}

--- a/src/services/ventaService.js
+++ b/src/services/ventaService.js
@@ -1,0 +1,51 @@
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  doc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs,
+} from 'firebase/firestore';
+import { db } from './firebase';
+
+const PRODUCT_SALES_COLLECTION = 'productSales';
+
+// Subscribe to product sales collection
+export function subscribeProductSales(callback) {
+  const colRef = collection(db, PRODUCT_SALES_COLLECTION);
+  const unsubscribe = onSnapshot(colRef, (snapshot) => {
+    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    callback(data);
+  });
+  return unsubscribe;
+}
+
+// Add a product sale record
+export async function addProductSale(sale) {
+  const docRef = await addDoc(collection(db, PRODUCT_SALES_COLLECTION), sale);
+  return { id: docRef.id, ...sale };
+}
+
+// Get a product sale by id
+export async function getProductSale(id) {
+  const snap = await getDoc(doc(db, PRODUCT_SALES_COLLECTION, id));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+// Update a product sale
+export function updateProductSale(id, data) {
+  return updateDoc(doc(db, PRODUCT_SALES_COLLECTION, id), data);
+}
+
+// Delete a product sale
+export function deleteProductSale(id) {
+  return deleteDoc(doc(db, PRODUCT_SALES_COLLECTION, id));
+}
+
+// Retrieve all product sales once
+export async function getAllProductSales() {
+  const snapshot = await getDocs(collection(db, PRODUCT_SALES_COLLECTION));
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+}


### PR DESCRIPTION
## Summary
- add firebase initialization using env variables
- introduce dedicated services for turnos, ventas and users
- switch components to new service imports and add security rules

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7ae884c832cae27612e481fd65d