### PR TITLE
Use HashRouter for GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Este proyecto utiliza Firebase. Crea un archivo `.env` en la raíz del proyecto 
 - `VITE_FIREBASE_APP_ID`
 
 Estos valores configuran el SDK de Firebase para la autenticación y el acceso a Firestore.
+
+## Despliegue en GitHub Pages
+
+La aplicación utiliza `HashRouter` para que las rutas funcionen correctamente al refrescar en GitHub Pages.
+Las URL tendrán la forma `https://esbreenn.github.io/barber-turnos-app/#/ruta`.
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,15 +2,15 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import App from './App';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace BrowserRouter with HashRouter to support hash-based URLs
- document HashRouter usage and GitHub Pages routing in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "@firebase/firestore")*

------
https://chatgpt.com/codex/tasks/task_e_68a92d39b214832cb03b13bd53c7a35a