### PR TITLE
Remove outdated redirect from 404 page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -2,10 +2,9 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Redireccionando...</title>
-  <meta http-equiv="refresh" content="0; url=https://esbreenn.github.io/barber-turnos-app/">
+  <title>Página no encontrada</title>
 </head>
 <body>
-  Si no eres redirigido automáticamente, haz clic <a href="https://esbreenn.github.io/barber-turnos-app/">aquí</a>.
-  </body>
+  <p>Página no encontrada. <a href="/">Volver al inicio</a>.</p>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- remove meta refresh redirect from 404 page and link to site root

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `python -m http.server 8090 --directory public & curl -s http://localhost:8090/404.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a92ee61be8832caa2637ff5c4eef9a