### PR TITLE
chore: remove homepage from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,5 @@
     "gh-pages": "^6.1.1",
     "globals": "^16.0.0",
     "vite": "^6.3.5"
-  },
-  "homepage": "https://esbreenn.github.io/barber-turnos-app/"
+  }
 }


### PR DESCRIPTION
## Summary
- remove deprecated homepage from package configuration

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "@firebase/auth" from firebase)*

------
https://chatgpt.com/codex/tasks/task_e_68a92fb9566c832c99ebb6dc325c0070