### PR TITLE
Scope turnos service by user

### DIFF
--- a/scripts/removeCompletado.js
+++ b/scripts/removeCompletado.js
@@ -1,8 +1,16 @@
+/* eslint-env node */
+import process from 'node:process';
 import { getAllTurnos, updateTurno } from '../src/services/turnoService.js';
 
+const [uid] = process.argv.slice(2);
+if (!uid) {
+  console.error('Usage: node removeCompletado.js <uid>');
+  process.exit(1);
+}
+
 async function removeCompletado() {
-  const turnos = await getAllTurnos();
-  const updates = turnos.map(t => updateTurno(t.id, { completado: undefined }));
+  const turnos = await getAllTurnos(uid);
+  const updates = turnos.map(t => updateTurno(uid, t.id, { completado: undefined }));
   await Promise.all(updates);
   console.log('Propiedad "completado" eliminada de todos los turnos.');
 }
@@ -10,3 +18,4 @@ async function removeCompletado() {
 removeCompletado().catch(err => {
   console.error('Error en la migración:', err);
 });
+

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
 import useServices from '../hooks/useServices';
+import { getCurrentUser } from '../services/authService';
 
 // Estado inicial: Ahora incluimos el servicio por defecto y el precio correspondiente
 const initialState = {
@@ -22,6 +23,7 @@ function AddTurno() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const { services, servicePrices } = useServices();
+  const currentUser = getCurrentUser();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -53,7 +55,7 @@ function AddTurno() {
     setLoading(true);
 
     try {
-      const existing = await findTurnoByDate(turno.fecha, turno.hora);
+      const existing = await findTurnoByDate(currentUser.uid, turno.fecha, turno.hora);
       if (existing) {
         toast.error("Este horario ya está ocupado. Por favor, elige otro.");
         setLoading(false);
@@ -64,7 +66,7 @@ function AddTurno() {
       // Aseguramos que se guarde como número.
       const precioNumerico = parseFloat(turno.precio);
 
-      await addTurno({ ...turno, precio: precioNumerico, creado: serverTimestamp() });
+      await addTurno(currentUser.uid, { ...turno, precio: precioNumerico, creado: serverTimestamp() });
       toast.success('Turno guardado con éxito');
       navigate('/');
 

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -6,6 +6,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
 import useServices from '../hooks/useServices';
+import { getCurrentUser } from '../services/authService';
 
 function EditTurno() {
   const { id } = useParams();
@@ -14,11 +15,12 @@ function EditTurno() {
   const [loading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const { services, servicePrices } = useServices();
+  const currentUser = getCurrentUser();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const turnoDoc = await getTurno(id);
+        const turnoDoc = await getTurno(currentUser.uid, id);
         if (turnoDoc) {
           const data = turnoDoc;
           setTurno({
@@ -42,7 +44,7 @@ function EditTurno() {
       }
     };
     fetchData();
-  }, [id, navigate]);
+  }, [id, navigate, currentUser]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -74,7 +76,7 @@ function EditTurno() {
     setIsSaving(true);
     
     try {
-      const existing = await findTurnoByDate(turno.fecha, turno.hora);
+      const existing = await findTurnoByDate(currentUser.uid, turno.fecha, turno.hora);
       if (existing && existing.id !== id) {
         toast.error("Este horario ya está ocupado por otro turno.");
         setIsSaving(false);
@@ -84,7 +86,7 @@ function EditTurno() {
       const precioNumerico = parseFloat(turno.precio);
 
       const { id: turnoId, ...dataToUpdate } = turno;
-      await updateTurno(turnoId, { ...dataToUpdate, precio: precioNumerico });
+      await updateTurno(currentUser.uid, turnoId, { ...dataToUpdate, precio: precioNumerico });
 
       toast.success('Turno actualizado con éxito');
       navigate('/');

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { subscribeTurnos } from '../services/turnoService';
 import { subscribeProductSales } from '../services/ventaService';
 import { formatCurrency } from '../utils/formatCurrency';
+import { getCurrentUser } from '../services/authService';
 
 function parseYearMonth(fecha) {
     const date = new Date(fecha);
@@ -19,6 +20,7 @@ function Finances() {
     const [selectedMonth, setSelectedMonth] = useState(today.getMonth() + 1);
     const [selectedYear, setSelectedYear] = useState(today.getFullYear());
     const [selectedCategory, setSelectedCategory] = useState('');
+    const currentUser = getCurrentUser();
 
     const productCategories = useMemo(() => {
         const categories = allProductSales.map((venta) => venta.categoria).filter(Boolean);
@@ -26,12 +28,13 @@ function Finances() {
     }, [allProductSales]);
 
     useEffect(() => {
-        const unsubscribe = subscribeTurnos((data) => {
+        if (!currentUser) return;
+        const unsubscribe = subscribeTurnos(currentUser.uid, (data) => {
             setAllTurnos(data);
             setLoadingTurnos(false);
         });
         return () => unsubscribe();
-    }, []);
+    }, [currentUser]);
 
     useEffect(() => {
         const unsubscribe = subscribeProductSales((data) => {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,20 +7,23 @@ import CalendarView from "../components/CalendarView";
 import TurnoList from "../components/TurnoList";
 import toast from 'react-hot-toast';
 import { formatCurrency } from "../utils/formatCurrency";
+import { getCurrentUser } from "../services/authService";
 
 function Home() {
   const [allTurnos, setAllTurnos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState(new Date()); // selectedDate por defecto es la fecha actual
   const navigate = useNavigate();
+  const currentUser = getCurrentUser();
 
   useEffect(() => {
-    const unsubscribe = subscribeTurnos((data) => {
+    if (!currentUser) return;
+    const unsubscribe = subscribeTurnos(currentUser.uid, (data) => {
       setAllTurnos(data);
       setLoading(false);
     });
     return () => unsubscribe();
-  }, []);
+  }, [currentUser]);
 
   const filteredTurnos = useMemo(() => {
     if (!selectedDate) return [];
@@ -80,7 +83,7 @@ function Home() {
 
   const handleDelete = async (id) => {
     if (window.confirm("¿Estás seguro de que quieres eliminar este turno?")) {
-      const promise = deleteTurno(id);
+      const promise = deleteTurno(currentUser.uid, id);
 
       toast.promise(promise, {
         loading: 'Eliminando turno...',

--- a/src/services/turnoService.js
+++ b/src/services/turnoService.js
@@ -12,11 +12,11 @@ import {
 } from 'firebase/firestore';
 import { db } from './firebase';
 
-const TURNOS_COLLECTION = 'turnos';
+const getTurnosCol = (uid) => collection(db, 'users', uid, 'turnos');
 
 // Subscribe to turnos collection
-export function subscribeTurnos(callback) {
-  const colRef = collection(db, TURNOS_COLLECTION);
+export function subscribeTurnos(uid, callback) {
+  const colRef = getTurnosCol(uid);
   const unsubscribe = onSnapshot(colRef, (snapshot) => {
     const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
     callback(data);
@@ -25,31 +25,31 @@ export function subscribeTurnos(callback) {
 }
 
 // Add new turno
-export async function addTurno(turno) {
-  const docRef = await addDoc(collection(db, TURNOS_COLLECTION), turno);
+export async function addTurno(uid, turno) {
+  const docRef = await addDoc(getTurnosCol(uid), turno);
   return { id: docRef.id, ...turno };
 }
 
 // Get turno by id
-export async function getTurno(id) {
-  const snap = await getDoc(doc(db, TURNOS_COLLECTION, id));
+export async function getTurno(uid, id) {
+  const snap = await getDoc(doc(db, 'users', uid, 'turnos', id));
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 // Update turno
-export function updateTurno(id, data) {
-  return updateDoc(doc(db, TURNOS_COLLECTION, id), data);
+export function updateTurno(uid, id, data) {
+  return updateDoc(doc(db, 'users', uid, 'turnos', id), data);
 }
 
 // Delete turno
-export function deleteTurno(id) {
-  return deleteDoc(doc(db, TURNOS_COLLECTION, id));
+export function deleteTurno(uid, id) {
+  return deleteDoc(doc(db, 'users', uid, 'turnos', id));
 }
 
 // Find turno by date and time
-export async function findTurnoByDate(fecha, hora) {
+export async function findTurnoByDate(uid, fecha, hora) {
   const q = query(
-    collection(db, TURNOS_COLLECTION),
+    getTurnosCol(uid),
     where('fecha', '==', fecha),
     where('hora', '==', hora)
   );
@@ -58,7 +58,7 @@ export async function findTurnoByDate(fecha, hora) {
 }
 
 // Retrieve all turnos once
-export async function getAllTurnos() {
-  const snapshot = await getDocs(collection(db, TURNOS_COLLECTION));
+export async function getAllTurnos(uid) {
+  const snapshot = await getDocs(getTurnosCol(uid));
   return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
 }


### PR DESCRIPTION
## Summary
- Scope turnos collections per user with `getTurnosCol` and pass `uid` to all turno service methods.
- Update pages and scripts to supply the current user's UID when calling turno operations.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a933b2bfd8832c95a5e2028346a22f