### PR TITLE
Use auth uid for turno operations

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,23 +7,23 @@ import CalendarView from "../components/CalendarView";
 import TurnoList from "../components/TurnoList";
 import toast from 'react-hot-toast';
 import { formatCurrency } from "../utils/formatCurrency";
-import { getCurrentUser } from "../services/authService";
+import { auth } from "../services/firebase";
 
 function Home() {
   const [allTurnos, setAllTurnos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState(new Date()); // selectedDate por defecto es la fecha actual
   const navigate = useNavigate();
-  const currentUser = getCurrentUser();
 
   useEffect(() => {
-    if (!currentUser) return;
-    const unsubscribe = subscribeTurnos(currentUser.uid, (data) => {
+    if (!auth.currentUser) return;
+    const uid = auth.currentUser.uid;
+    const unsubscribe = subscribeTurnos(uid, (data) => {
       setAllTurnos(data);
       setLoading(false);
     });
     return () => unsubscribe();
-  }, [currentUser]);
+  }, []);
 
   const filteredTurnos = useMemo(() => {
     if (!selectedDate) return [];
@@ -83,7 +83,8 @@ function Home() {
 
   const handleDelete = async (id) => {
     if (window.confirm("¿Estás seguro de que quieres eliminar este turno?")) {
-      const promise = deleteTurno(currentUser.uid, id);
+      const uid = auth.currentUser.uid;
+      const promise = deleteTurno(uid, id);
 
       toast.promise(promise, {
         loading: 'Eliminando turno...',


### PR DESCRIPTION
## Summary
- derive the authenticated user's UID from Firebase auth
- use this UID when subscribing to or deleting turnos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a934fb0694832c967ab3221cf615f9