### PR TITLE
Filter finance turnos by authenticated user

### DIFF
--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { subscribeTurnos } from '../services/turnoService';
 import { subscribeProductSales } from '../services/ventaService';
 import { formatCurrency } from '../utils/formatCurrency';
-import { getCurrentUser } from '../services/authService';
+import { auth } from '../services/firebase';
 
 function parseYearMonth(fecha) {
     const date = new Date(fecha);
@@ -20,7 +20,6 @@ function Finances() {
     const [selectedMonth, setSelectedMonth] = useState(today.getMonth() + 1);
     const [selectedYear, setSelectedYear] = useState(today.getFullYear());
     const [selectedCategory, setSelectedCategory] = useState('');
-    const currentUser = getCurrentUser();
 
     const productCategories = useMemo(() => {
         const categories = allProductSales.map((venta) => venta.categoria).filter(Boolean);
@@ -28,13 +27,13 @@ function Finances() {
     }, [allProductSales]);
 
     useEffect(() => {
-        if (!currentUser) return;
-        const unsubscribe = subscribeTurnos(currentUser.uid, (data) => {
+        const uid = auth.currentUser.uid;
+        const unsubscribe = subscribeTurnos(uid, (data) => {
             setAllTurnos(data);
             setLoadingTurnos(false);
         });
         return () => unsubscribe();
-    }, [currentUser]);
+    }, []);
 
     useEffect(() => {
         const unsubscribe = subscribeProductSales((data) => {


### PR DESCRIPTION
## Summary
- Use Firebase auth to obtain current UID in `Finances` page
- Subscribe to `turnos` using this UID so calculations are scoped to the logged-in user

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a935a42b2c832c8af14b3286cfd7fb