### PR TITLE
Ensure turnos are stored under user subcollection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,19 +1,19 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Turnos collection
-    match /turnos/{document} {
-      allow read, write: if request.auth != null;
-    }
-
     // Product sales collection
     match /productSales/{document} {
       allow read, write: if request.auth != null;
     }
 
-    // Users collection
+    // Users collection and subcollections
     match /users/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
+
+      // Turnos subcollection per user
+      match /turnos/{turnoId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Deny access by default


### PR DESCRIPTION
## Summary
- Update Firestore rules to remove legacy top-level `turnos` collection and secure nested `users/{userId}/turnos` path.

## Testing
- `npm run lint`
- `node --env-file=.env scripts/testCrud.mjs` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a937399a3c832cabb6c5954a640f54