### PR TITLE
Scope product sales per user

### DIFF
--- a/src/pages/AddProducto.jsx
+++ b/src/pages/AddProducto.jsx
@@ -6,6 +6,7 @@ import { serverTimestamp } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import ProductoForm from '../components/ProductoForm';
+import { auth } from '../services/firebase';
 
 const initialState = {
   nombre: '',
@@ -19,6 +20,7 @@ function AddProducto() {
   const [producto, setProducto] = useState(initialState);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const uid = auth.currentUser.uid;
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -40,7 +42,7 @@ function AddProducto() {
     setLoading(true);
 
     try {
-      await addProductSale({
+      await addProductSale(uid, {
         nombre: producto.nombre,
         costo: Number(producto.costo),
         precioVenta: Number(producto.precioVenta),

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -36,7 +36,8 @@ function Finances() {
     }, []);
 
     useEffect(() => {
-        const unsubscribe = subscribeProductSales((data) => {
+        const uid = auth.currentUser.uid;
+        const unsubscribe = subscribeProductSales(uid, (data) => {
             setAllProductSales(data);
             setLoadingProducts(false);
         });

--- a/src/services/ventaService.js
+++ b/src/services/ventaService.js
@@ -10,11 +10,12 @@ import {
 } from 'firebase/firestore';
 import { db } from './firebase';
 
-const PRODUCT_SALES_COLLECTION = 'productSales';
+const getProductSalesCol = (uid) =>
+  collection(db, 'users', uid, 'ventasProductos');
 
 // Subscribe to product sales collection
-export function subscribeProductSales(callback) {
-  const colRef = collection(db, PRODUCT_SALES_COLLECTION);
+export function subscribeProductSales(uid, callback) {
+  const colRef = getProductSalesCol(uid);
   const unsubscribe = onSnapshot(colRef, (snapshot) => {
     const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
     callback(data);
@@ -23,29 +24,29 @@ export function subscribeProductSales(callback) {
 }
 
 // Add a product sale record
-export async function addProductSale(sale) {
-  const docRef = await addDoc(collection(db, PRODUCT_SALES_COLLECTION), sale);
+export async function addProductSale(uid, sale) {
+  const docRef = await addDoc(getProductSalesCol(uid), sale);
   return { id: docRef.id, ...sale };
 }
 
 // Get a product sale by id
-export async function getProductSale(id) {
-  const snap = await getDoc(doc(db, PRODUCT_SALES_COLLECTION, id));
+export async function getProductSale(uid, id) {
+  const snap = await getDoc(doc(db, 'users', uid, 'ventasProductos', id));
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 // Update a product sale
-export function updateProductSale(id, data) {
-  return updateDoc(doc(db, PRODUCT_SALES_COLLECTION, id), data);
+export function updateProductSale(uid, id, data) {
+  return updateDoc(doc(db, 'users', uid, 'ventasProductos', id), data);
 }
 
 // Delete a product sale
-export function deleteProductSale(id) {
-  return deleteDoc(doc(db, PRODUCT_SALES_COLLECTION, id));
+export function deleteProductSale(uid, id) {
+  return deleteDoc(doc(db, 'users', uid, 'ventasProductos', id));
 }
 
 // Retrieve all product sales once
-export async function getAllProductSales() {
-  const snapshot = await getDocs(collection(db, PRODUCT_SALES_COLLECTION));
+export async function getAllProductSales(uid) {
+  const snapshot = await getDocs(getProductSalesCol(uid));
   return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
 }


### PR DESCRIPTION
## Summary
- Scope product sale operations to each user's `ventasProductos` subcollection via new `getProductSalesCol`
- Pass user ID when recording product sales and when subscribing to product sale updates
- Remove global product sales collection constant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a93828ee38832ca5cb541d06bcbd00