### PR TITLE
Limit Firestore access to user-scoped data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ Este proyecto utiliza Firebase. Crea un archivo `.env` en la raíz del proyecto 
 - `VITE_FIREBASE_APP_ID`
 
 Estos valores configuran el SDK de Firebase para la autenticación y el acceso a Firestore.
+
+## Estructura de la base de datos y reglas de seguridad
+
+La base de datos de Firestore se estructura en torno a una colección de usuarios:
+
+```
+users/{userId}
+  turnos/{turnoId}
+  ventasProductos/{ventaId}
+```
+
+Cada documento y subcolección solo puede ser leído o escrito por el usuario autenticado cuyo ID coincide con `userId`. Se eliminaron las colecciones globales de `turnos` y `productSales` para evitar que un usuario autenticado acceda o modifique datos de otros. De esta manera se protege la privacidad de la información y se reducen riesgos de manipulación no autorizada.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,10 +1,13 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Product sales collection
-    match /productSales/{document} {
-      allow read, write: if request.auth != null;
-    }
+    // Colecciones globales deshabilitadas
+    // match /turnos/{turnoId} {
+    //   allow read, write: if request.auth != null;
+    // }
+    // match /productSales/{document} {
+    //   allow read, write: if request.auth != null;
+    // }
 
     // Users collection and subcollections
     match /users/{userId} {
@@ -12,6 +15,11 @@ service cloud.firestore {
 
       // Turnos subcollection per user
       match /turnos/{turnoId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      // Ventas de productos subcollection per user
+      match /ventasProductos/{ventaId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
     }


### PR DESCRIPTION
## Summary
- disable global `turnos` and `productSales` access in Firestore rules
- add per-user `turnos` and `ventasProductos` rules
- document database structure and security rationale in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a998094334832cbd4535962dd7e550