### PR TITLE
Use current Firebase user ID for ventas service

### DIFF
--- a/src/services/ventaService.js
+++ b/src/services/ventaService.js
@@ -8,14 +8,14 @@ import {
   deleteDoc,
   getDocs,
 } from 'firebase/firestore';
-import { db } from './firebase';
+import { db, auth } from './firebase';
 
-const getProductSalesCol = (uid) =>
-  collection(db, 'users', uid, 'ventasProductos');
+const getProductSalesCol = () =>
+  collection(db, 'users', auth.currentUser.uid, 'ventasProductos');
 
 // Subscribe to product sales collection
-export function subscribeProductSales(uid, callback) {
-  const colRef = getProductSalesCol(uid);
+export function subscribeProductSales(callback) {
+  const colRef = getProductSalesCol();
   const unsubscribe = onSnapshot(colRef, (snapshot) => {
     const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
     callback(data);
@@ -24,29 +24,36 @@ export function subscribeProductSales(uid, callback) {
 }
 
 // Add a product sale record
-export async function addProductSale(uid, sale) {
-  const docRef = await addDoc(getProductSalesCol(uid), sale);
+export async function addProductSale(sale) {
+  const docRef = await addDoc(getProductSalesCol(), sale);
   return { id: docRef.id, ...sale };
 }
 
 // Get a product sale by id
-export async function getProductSale(uid, id) {
-  const snap = await getDoc(doc(db, 'users', uid, 'ventasProductos', id));
+export async function getProductSale(id) {
+  const snap = await getDoc(
+    doc(db, 'users', auth.currentUser.uid, 'ventasProductos', id)
+  );
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 // Update a product sale
-export function updateProductSale(uid, id, data) {
-  return updateDoc(doc(db, 'users', uid, 'ventasProductos', id), data);
+export function updateProductSale(id, data) {
+  return updateDoc(
+    doc(db, 'users', auth.currentUser.uid, 'ventasProductos', id),
+    data
+  );
 }
 
 // Delete a product sale
-export function deleteProductSale(uid, id) {
-  return deleteDoc(doc(db, 'users', uid, 'ventasProductos', id));
+export function deleteProductSale(id) {
+  return deleteDoc(
+    doc(db, 'users', auth.currentUser.uid, 'ventasProductos', id)
+  );
 }
 
 // Retrieve all product sales once
-export async function getAllProductSales(uid) {
-  const snapshot = await getDocs(getProductSalesCol(uid));
+export async function getAllProductSales() {
+  const snapshot = await getDocs(getProductSalesCol());
   return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
 }


### PR DESCRIPTION
## Summary
- Import `auth` in `ventaService` and use `auth.currentUser.uid` for product sales paths.
- Remove `uid` parameters from venta service functions.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a998b6ee44832ca5e4e88917340237