### PR TITLE
refactor: use implicit auth in services

### DIFF
--- a/src/pages/AddProducto.jsx
+++ b/src/pages/AddProducto.jsx
@@ -6,7 +6,6 @@ import { serverTimestamp } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import ProductoForm from '../components/ProductoForm';
-import { auth } from '../services/firebase';
 
 const initialState = {
   nombre: '',
@@ -41,8 +40,7 @@ function AddProducto() {
     setLoading(true);
 
     try {
-      const uid = auth.currentUser.uid;
-      await addProductSale(uid, {
+      await addProductSale({
         nombre: producto.nombre,
         costo: Number(producto.costo),
         precioVenta: Number(producto.precioVenta),

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -7,7 +7,6 @@ import { useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
 import useServices from '../hooks/useServices';
-import { auth } from '../services/firebase';
 
 // Estado inicial: Ahora incluimos el servicio por defecto y el precio correspondiente
 const initialState = {
@@ -23,7 +22,6 @@ function AddTurno() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const { services, servicePrices } = useServices();
-  const uid = auth.currentUser.uid;
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -55,7 +53,7 @@ function AddTurno() {
     setLoading(true);
 
     try {
-      const existing = await findTurnoByDate(uid, turno.fecha, turno.hora);
+      const existing = await findTurnoByDate(turno.fecha, turno.hora);
       if (existing) {
         toast.error("Este horario ya está ocupado. Por favor, elige otro.");
         setLoading(false);
@@ -66,7 +64,7 @@ function AddTurno() {
       // Aseguramos que se guarde como número.
       const precioNumerico = parseFloat(turno.precio);
 
-      await addTurno(uid, { ...turno, precio: precioNumerico, creado: serverTimestamp() });
+      await addTurno({ ...turno, precio: precioNumerico, creado: serverTimestamp() });
       toast.success('Turno guardado con éxito');
       navigate('/');
 

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -6,7 +6,6 @@ import { useParams, useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
 import useServices from '../hooks/useServices';
-import { auth } from '../services/firebase';
 
 function EditTurno() {
   const { id } = useParams();
@@ -15,12 +14,11 @@ function EditTurno() {
   const [loading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const { services, servicePrices } = useServices();
-  const uid = auth.currentUser.uid;
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const turnoDoc = await getTurno(uid, id);
+        const turnoDoc = await getTurno(id);
         if (turnoDoc) {
           const data = turnoDoc;
           setTurno({
@@ -44,7 +42,7 @@ function EditTurno() {
       }
     };
     fetchData();
-  }, [id, navigate, uid]);
+  }, [id, navigate]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -76,7 +74,7 @@ function EditTurno() {
     setIsSaving(true);
     
     try {
-      const existing = await findTurnoByDate(uid, turno.fecha, turno.hora);
+      const existing = await findTurnoByDate(turno.fecha, turno.hora);
       if (existing && existing.id !== id) {
         toast.error("Este horario ya está ocupado por otro turno.");
         setIsSaving(false);
@@ -86,7 +84,7 @@ function EditTurno() {
       const precioNumerico = parseFloat(turno.precio);
 
       const { id: turnoId, ...dataToUpdate } = turno;
-      await updateTurno(uid, turnoId, { ...dataToUpdate, precio: precioNumerico });
+      await updateTurno(turnoId, { ...dataToUpdate, precio: precioNumerico });
 
       toast.success('Turno actualizado con éxito');
       navigate('/');

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -4,7 +4,6 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { subscribeTurnos } from '../services/turnoService';
 import { subscribeProductSales } from '../services/ventaService';
 import { formatCurrency } from '../utils/formatCurrency';
-import { auth } from '../services/firebase';
 
 function parseYearMonth(fecha) {
     const date = new Date(fecha);
@@ -27,8 +26,7 @@ function Finances() {
     }, [allProductSales]);
 
     useEffect(() => {
-        const uid = auth.currentUser.uid;
-        const unsubscribe = subscribeTurnos(uid, (data) => {
+        const unsubscribe = subscribeTurnos((data) => {
             setAllTurnos(data);
             setLoadingTurnos(false);
         });
@@ -36,8 +34,7 @@ function Finances() {
     }, []);
 
     useEffect(() => {
-        const uid = auth.currentUser.uid;
-        const unsubscribe = subscribeProductSales(uid, (data) => {
+        const unsubscribe = subscribeProductSales((data) => {
             setAllProductSales(data);
             setLoadingProducts(false);
         });

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,7 +7,6 @@ import CalendarView from "../components/CalendarView";
 import TurnoList from "../components/TurnoList";
 import toast from 'react-hot-toast';
 import { formatCurrency } from "../utils/formatCurrency";
-import { auth } from "../services/firebase";
 
 function Home() {
   const [allTurnos, setAllTurnos] = useState([]);
@@ -16,9 +15,7 @@ function Home() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!auth.currentUser) return;
-    const uid = auth.currentUser.uid;
-    const unsubscribe = subscribeTurnos(uid, (data) => {
+    const unsubscribe = subscribeTurnos((data) => {
       setAllTurnos(data);
       setLoading(false);
     });
@@ -83,8 +80,7 @@ function Home() {
 
   const handleDelete = async (id) => {
     if (window.confirm("¿Estás seguro de que quieres eliminar este turno?")) {
-      const uid = auth.currentUser.uid;
-      const promise = deleteTurno(uid, id);
+      const promise = deleteTurno(id);
 
       toast.promise(promise, {
         loading: 'Eliminando turno...',


### PR DESCRIPTION
## Summary
- stop retrieving uid from Firebase in pages
- call subscription and mutation services without passing uid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a999643a38832ca631f2ccb6d28074