### PR TITLE
Allow admins to access user data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,16 +11,19 @@ service cloud.firestore {
 
     // Users collection and subcollections
     match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null &&
+        (request.auth.uid == userId || request.auth.token.role == 'admin');
 
       // Turnos subcollection per user
       match /turnos/{turnoId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
+        allow read, write: if request.auth != null &&
+          (request.auth.uid == userId || request.auth.token.role == 'admin');
       }
 
       // Ventas de productos subcollection per user
       match /ventasProductos/{ventaId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
+        allow read, write: if request.auth != null &&
+          (request.auth.uid == userId || request.auth.token.role == 'admin');
       }
     }
 


### PR DESCRIPTION
## Summary
- permit admins to read and write data for any user

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a99ab649cc832c956b35f70b4e99a0