### PR TITLE
Add helper to enforce authenticated UID in services

### DIFF
--- a/src/pages/AddProducto.jsx
+++ b/src/pages/AddProducto.jsx
@@ -52,7 +52,11 @@ function AddProducto() {
       navigate('/');
     } catch (err) {
       console.error('Error al registrar la venta:', err);
-      toast.error('Hubo un error al guardar la venta.');
+      if (err.message === 'No authenticated user') {
+        navigate('/login');
+      } else {
+        toast.error('Hubo un error al guardar la venta.');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -69,8 +69,12 @@ function AddTurno() {
       navigate('/');
 
     } catch (err) {
-      console.error("Error en handleSubmit de AddTurno:", err); 
-      toast.error('Hubo un error al validar o guardar el turno.');
+      console.error("Error en handleSubmit de AddTurno:", err);
+      if (err.message === 'No authenticated user') {
+        navigate('/login');
+      } else {
+        toast.error('Hubo un error al validar o guardar el turno.');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -35,8 +35,12 @@ function EditTurno() {
         }
       } catch (err) {
         console.error('Error en fetchTurno de EditTurno:', err);
-        toast.error('Error al cargar el turno.');
-        navigate('/');
+        if (err.message === 'No authenticated user') {
+          navigate('/login');
+        } else {
+          toast.error('Error al cargar el turno.');
+          navigate('/');
+        }
       } finally {
         setLoading(false);
       }
@@ -91,7 +95,11 @@ function EditTurno() {
 
     } catch (err) {
       console.error("Error en handleSubmit de EditTurno:", err);
-      toast.error('Error al actualizar el turno.');
+      if (err.message === 'No authenticated user') {
+        navigate('/login');
+      } else {
+        toast.error('Error al actualizar el turno.');
+      }
     } finally {
       setIsSaving(false);
     }

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { subscribeTurnos } from '../services/turnoService';
 import { subscribeProductSales } from '../services/ventaService';
 import { formatCurrency } from '../utils/formatCurrency';
+import { useNavigate } from 'react-router-dom';
 
 function parseYearMonth(fecha) {
     const date = new Date(fecha);
@@ -19,6 +20,7 @@ function Finances() {
     const [selectedMonth, setSelectedMonth] = useState(today.getMonth() + 1);
     const [selectedYear, setSelectedYear] = useState(today.getFullYear());
     const [selectedCategory, setSelectedCategory] = useState('');
+    const navigate = useNavigate();
 
     const productCategories = useMemo(() => {
         const categories = allProductSales.map((venta) => venta.categoria).filter(Boolean);
@@ -26,20 +28,34 @@ function Finances() {
     }, [allProductSales]);
 
     useEffect(() => {
-        const unsubscribe = subscribeTurnos((data) => {
-            setAllTurnos(data);
-            setLoadingTurnos(false);
-        });
-        return () => unsubscribe();
-    }, []);
+        try {
+            const unsubscribe = subscribeTurnos((data) => {
+                setAllTurnos(data);
+                setLoadingTurnos(false);
+            });
+            return () => unsubscribe();
+        } catch (err) {
+            console.error('Error al suscribirse a turnos:', err);
+            if (err.message === 'No authenticated user') {
+                navigate('/login');
+            }
+        }
+    }, [navigate]);
 
     useEffect(() => {
-        const unsubscribe = subscribeProductSales((data) => {
-            setAllProductSales(data);
-            setLoadingProducts(false);
-        });
-        return () => unsubscribe();
-    }, []);
+        try {
+            const unsubscribe = subscribeProductSales((data) => {
+                setAllProductSales(data);
+                setLoadingProducts(false);
+            });
+            return () => unsubscribe();
+        } catch (err) {
+            console.error('Error al suscribirse a ventas:', err);
+            if (err.message === 'No authenticated user') {
+                navigate('/login');
+            }
+        }
+    }, [navigate]);
 
     // Cálculo de las ganancias y filtrado de turnos para el mes y año seleccionados
     // ¡Aquí añadimos el contador de cortes!

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -15,12 +15,19 @@ function Home() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const unsubscribe = subscribeTurnos((data) => {
-      setAllTurnos(data);
-      setLoading(false);
-    });
-    return () => unsubscribe();
-  }, []);
+    try {
+      const unsubscribe = subscribeTurnos((data) => {
+        setAllTurnos(data);
+        setLoading(false);
+      });
+      return () => unsubscribe();
+    } catch (err) {
+      console.error('Error al suscribirse a turnos:', err);
+      if (err.message === 'No authenticated user') {
+        navigate('/login');
+      }
+    }
+  }, [navigate]);
 
   const filteredTurnos = useMemo(() => {
     if (!selectedDate) return [];
@@ -80,13 +87,15 @@ function Home() {
 
   const handleDelete = async (id) => {
     if (window.confirm("¿Estás seguro de que quieres eliminar este turno?")) {
-      const promise = deleteTurno(id);
-
-      toast.promise(promise, {
+      toast.promise(deleteTurno(id), {
         loading: 'Eliminando turno...',
         success: 'Turno eliminado con éxito',
         error: (err) => {
           console.error("Error al eliminar:", err);
+          if (err.message === 'No authenticated user') {
+            navigate('/login');
+            return 'Sesión expirada';
+          }
           return 'No se pudo eliminar el turno.';
         }
       });

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -9,29 +9,37 @@ import { db, auth } from './firebase';
 
 const USERS_COLLECTION = 'users';
 
+function getUidOrThrow() {
+  const uid = auth.currentUser?.uid;
+  if (!uid) {
+    throw new Error('No authenticated user');
+  }
+  return uid;
+}
+
 // Add a new user document for the authenticated user
 export async function addUser(data) {
-  const uid = auth.currentUser.uid;
+  const uid = getUidOrThrow();
   await setDoc(doc(db, USERS_COLLECTION, uid), data);
   return { id: uid, ...data };
 }
 
 // Get the authenticated user's document
 export async function getUser() {
-  const uid = auth.currentUser.uid;
+  const uid = getUidOrThrow();
   const snap = await getDoc(doc(db, USERS_COLLECTION, uid));
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 // Update the authenticated user's document
 export function updateUser(data) {
-  const uid = auth.currentUser.uid;
+  const uid = getUidOrThrow();
   return updateDoc(doc(db, USERS_COLLECTION, uid), data);
 }
 
 // Delete the authenticated user's document
 export function deleteUser() {
-  const uid = auth.currentUser.uid;
+  const uid = getUidOrThrow();
   return deleteDoc(doc(db, USERS_COLLECTION, uid));
 }
 

--- a/src/services/ventaService.js
+++ b/src/services/ventaService.js
@@ -10,8 +10,16 @@ import {
 } from 'firebase/firestore';
 import { db, auth } from './firebase';
 
+function getUidOrThrow() {
+  const uid = auth.currentUser?.uid;
+  if (!uid) {
+    throw new Error('No authenticated user');
+  }
+  return uid;
+}
+
 const getProductSalesCol = () =>
-  collection(db, 'users', auth.currentUser.uid, 'ventasProductos');
+  collection(db, 'users', getUidOrThrow(), 'ventasProductos');
 
 // Subscribe to product sales collection
 export function subscribeProductSales(callback) {
@@ -31,24 +39,27 @@ export async function addProductSale(sale) {
 
 // Get a product sale by id
 export async function getProductSale(id) {
+  const uid = getUidOrThrow();
   const snap = await getDoc(
-    doc(db, 'users', auth.currentUser.uid, 'ventasProductos', id)
+    doc(db, 'users', uid, 'ventasProductos', id)
   );
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 // Update a product sale
 export function updateProductSale(id, data) {
+  const uid = getUidOrThrow();
   return updateDoc(
-    doc(db, 'users', auth.currentUser.uid, 'ventasProductos', id),
+    doc(db, 'users', uid, 'ventasProductos', id),
     data
   );
 }
 
 // Delete a product sale
 export function deleteProductSale(id) {
+  const uid = getUidOrThrow();
   return deleteDoc(
-    doc(db, 'users', auth.currentUser.uid, 'ventasProductos', id)
+    doc(db, 'users', uid, 'ventasProductos', id)
   );
 }
 


### PR DESCRIPTION
## Summary
- add `getUidOrThrow` to user, turno and venta services
- redirect to login when services throw unauthenticated error

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9dbb445b8832c8cbb7a4a919a8934