### PR TITLE
test: add vitest setup and service tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ users/{userId}
 ```
 
 Cada documento y subcolección solo puede ser leído o escrito por el usuario autenticado cuyo ID coincide con `userId`. Se eliminaron las colecciones globales de `turnos` y `productSales` para evitar que un usuario autenticado acceda o modifique datos de otros. De esta manera se protege la privacidad de la información y se reducen riesgos de manipulación no autorizada.
+
+## Ejecutar tests
+
+Instala las dependencias y luego ejecuta:
+
+```bash
+npm test
+```
+
+Esto ejecutará la suite de pruebas con Vitest.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "test": "vitest"
   },
   "dependencies": {
     "bootstrap": "^5.3.6",
@@ -34,6 +35,9 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "gh-pages": "^6.1.1",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^2.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.5"
   }
 }

--- a/src/services/services.test.js
+++ b/src/services/services.test.js
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { addTurno } from './turnoService'
+import { addProductSale, getAllProductSales } from './ventaService'
+
+// Simple in-memory store to mock Firestore
+const store = {}
+
+vi.mock('./firebase', () => ({
+  db: {},
+  auth: { currentUser: { uid: 'test-uid' } }
+}))
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...path) => path.join('/'),
+  addDoc: async (colPath, data) => {
+    const id = Math.random().toString(36).slice(2)
+    if (!store[colPath]) store[colPath] = []
+    store[colPath].push({ id, ...data })
+    return { id }
+  },
+  onSnapshot: () => () => {},
+  doc: (...path) => ({ colPath: path.slice(0, -1).join('/'), id: path.at(-1) }),
+  getDoc: async (ref) => {
+    const docs = store[ref.colPath] || []
+    const d = docs.find((x) => x.id === ref.id)
+    return { exists: () => !!d, id: ref.id, data: () => d }
+  },
+  updateDoc: async () => {},
+  deleteDoc: async () => {},
+  query: (colPath, ...filters) => ({ colPath, filters }),
+  where: (field, _op, value) => ({ field, value }),
+  getDocs: async (colOrQuery) => {
+    const colPath = typeof colOrQuery === 'string' ? colOrQuery : colOrQuery.colPath
+    const filters = typeof colOrQuery === 'string' ? [] : colOrQuery.filters
+    let docs = store[colPath] || []
+    if (filters.length) {
+      docs = docs.filter((doc) => filters.every((f) => doc[f.field] === f.value))
+    }
+    return { docs: docs.map((doc) => ({ id: doc.id, data: () => doc })) }
+  },
+}))
+
+beforeEach(() => {
+  for (const key in store) delete store[key]
+})
+
+describe('addTurno', () => {
+  test('rechaza horarios duplicados', async () => {
+    await addTurno({ fecha: '2025-01-01', hora: '10:00' })
+    await expect(
+      addTurno({ fecha: '2025-01-01', hora: '10:00' })
+    ).rejects.toThrow()
+  })
+})
+
+describe('addProductSale', () => {
+  test('guarda datos válidos', async () => {
+    const sale = {
+      nombre: 'Gel',
+      costo: 5,
+      precioVenta: 10,
+      fecha: '2025-01-01',
+      categoria: 'cuidado',
+    }
+    const saved = await addProductSale(sale)
+    expect(saved).toMatchObject(sale)
+    const all = await getAllProductSales()
+    expect(all).toContainEqual(saved)
+  })
+})

--- a/src/services/turnoService.js
+++ b/src/services/turnoService.js
@@ -32,8 +32,12 @@ export function subscribeTurnos(callback) {
   return unsubscribe;
 }
 
-// Add new turno
+// Add new turno ensuring no duplicate schedule exists
 export async function addTurno(turno) {
+  const existing = await findTurnoByDate(turno.fecha, turno.hora);
+  if (existing) {
+    throw new Error('Turno duplicado');
+  }
   const docRef = await addDoc(getTurnosCol(), turno);
   return { id: docRef.id, ...turno };
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,11 @@
-// vite.config.js
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/', // ¡CAMBIA ESTO!
+  base: '/',
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- add Vitest and Testing Library config
- reject duplicate turnos and test core services
- document running tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9de7dd3a8832c9c3dd1b79b7bd9b6