### PR TITLE
feat: manage barber services in Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,6 +25,12 @@ service cloud.firestore {
         allow read, write: if request.auth != null &&
           (request.auth.uid == userId || request.auth.token.role == 'admin');
       }
+
+      // Services subcollection per user
+      match /services/{serviceId} {
+        allow read, write: if request.auth != null &&
+          (request.auth.uid == userId || request.auth.token.role == 'admin');
+      }
     }
 
     // Deny access by default

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import EditTurno from "./pages/EditTurno";
 import Login from "./pages/Login";
 import Finances from "./pages/Finances";
 import AddProducto from "./pages/AddProducto";
+import ServicesPanel from "./pages/ServicesPanel";
 
 import Navbar from "./components/Navbar";
 
@@ -52,6 +53,10 @@ function App() {
           <Route
             path="/venta-producto"
             element={<PrivateRoute user={currentUser}><AddProducto /></PrivateRoute>}
+          />
+          <Route
+            path="/servicios"
+            element={<PrivateRoute user={currentUser}><ServicesPanel /></PrivateRoute>}
           />
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -9,6 +9,7 @@ import {
   FaChartLine,
   FaShoppingBag,
   FaSignOutAlt,
+  FaCut,
 } from 'react-icons/fa';
 
 function Navbar({ currentUser }) {
@@ -37,6 +38,9 @@ function Navbar({ currentUser }) {
         </Link>
         <Link to="/venta-producto" className="btn btn-nav nav-products">
           <FaShoppingBag className="me-1" /> Venta de Producto
+        </Link>
+        <Link to="/servicios" className="btn btn-nav nav-services">
+          <FaCut className="me-1" /> Servicios
         </Link>
       </div>
       <div className="user-actions">

--- a/src/components/ServiceForm.jsx
+++ b/src/components/ServiceForm.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+function ServiceForm({ serviceData, onFormChange, onSubmit, isSaving, submitText }) {
+  const { nombre, precio } = serviceData;
+
+  return (
+    <form onSubmit={onSubmit}>
+      <div className="mb-3">
+        <label htmlFor="nombre" className="form-label">Nombre</label>
+        <input
+          type="text"
+          className="form-control"
+          id="nombre"
+          name="nombre"
+          value={nombre}
+          onChange={onFormChange}
+          required
+        />
+      </div>
+      <div className="mb-3">
+        <label htmlFor="precio" className="form-label">Precio</label>
+        <input
+          type="number"
+          className="form-control"
+          id="precio"
+          name="precio"
+          value={precio}
+          onChange={onFormChange}
+          required
+        />
+      </div>
+      <button type="submit" className="btn btn-primary w-100" disabled={isSaving}>
+        {isSaving ? 'Guardando...' : submitText}
+      </button>
+    </form>
+  );
+}
+
+export default ServiceForm;
+

--- a/src/hooks/useServices.js
+++ b/src/hooks/useServices.js
@@ -1,24 +1,28 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { subscribeServices } from '../services/serviceService';
 
-// Hook simplificado: devuelve dos servicios fijos con precios predeterminados.
 function useServices() {
-  const services = useMemo(
-    () => [
-      { id: 'corte', nombre: 'Corte de Cabello' },
-      { id: 'corte-barba', nombre: 'Corte de Cabello y Barba' },
-    ],
-    []
-  );
+  const [services, setServices] = useState([]);
 
-  const servicePrices = useMemo(
-    () => ({
-      'Corte de Cabello': 9000,
-      'Corte de Cabello y Barba': 12000,
-    }),
-    []
-  );
+  useEffect(() => {
+    let unsubscribe;
+    try {
+      unsubscribe = subscribeServices(setServices);
+    } catch (err) {
+      console.error('Error subscribing to services:', err);
+    }
+    return () => unsubscribe && unsubscribe();
+  }, []);
+
+  const servicePrices = useMemo(() => (
+    services.reduce((acc, s) => {
+      acc[s.nombre] = s.precio;
+      return acc;
+    }, {})
+  ), [services]);
 
   return { services, servicePrices };
 }
 
 export default useServices;
+

--- a/src/pages/ServicesPanel.jsx
+++ b/src/pages/ServicesPanel.jsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import useServices from '../hooks/useServices';
+import ServiceForm from '../components/ServiceForm';
+import { addService, updateService, deleteService } from '../services/serviceService';
+import toast from 'react-hot-toast';
+import { formatCurrency } from '../utils/formatCurrency';
+
+const initialState = { nombre: '', precio: '' };
+
+function ServicesPanel() {
+  const { services } = useServices();
+  const [service, setService] = useState(initialState);
+  const [editingId, setEditingId] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setService((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!service.nombre.trim() || !service.precio) {
+      toast.error('Nombre y precio son obligatorios.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const payload = { nombre: service.nombre, precio: Number(service.precio) };
+      if (editingId) {
+        await updateService(editingId, payload);
+        toast.success('Servicio actualizado');
+      } else {
+        await addService(payload);
+        toast.success('Servicio agregado');
+      }
+      setService(initialState);
+      setEditingId(null);
+    } catch (err) {
+      console.error('Error al guardar servicio:', err);
+      toast.error('No se pudo guardar el servicio.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (svc) => {
+    setService({ nombre: svc.nombre, precio: svc.precio });
+    setEditingId(svc.id);
+  };
+
+  const handleCancel = () => {
+    setService(initialState);
+    setEditingId(null);
+  };
+
+  const handleDelete = async (id) => {
+    if (window.confirm('¿Eliminar servicio?')) {
+      try {
+        await deleteService(id);
+        toast.success('Servicio eliminado');
+      } catch (err) {
+        console.error('Error al eliminar servicio:', err);
+        toast.error('No se pudo eliminar el servicio.');
+      }
+    }
+  };
+
+  return (
+    <div className="container mt-4" style={{ maxWidth: '600px' }}>
+      <h2 className="mb-4">{editingId ? 'Editar Servicio' : 'Agregar Servicio'}</h2>
+      <ServiceForm
+        serviceData={service}
+        onFormChange={handleChange}
+        onSubmit={handleSubmit}
+        isSaving={loading}
+        submitText={editingId ? 'Actualizar Servicio' : 'Agregar Servicio'}
+      />
+      {editingId && (
+        <button className="btn btn-secondary mt-2 w-100" onClick={handleCancel} disabled={loading}>
+          Cancelar
+        </button>
+      )}
+
+      <h3 className="mt-5 mb-3">Mis Servicios</h3>
+      {services.length === 0 ? (
+        <p>No hay servicios.</p>
+      ) : (
+        <ul className="list-group">
+          {services.map((svc) => (
+            <li
+              key={svc.id}
+              className="list-group-item d-flex justify-content-between align-items-center"
+            >
+              <span>{svc.nombre} - {formatCurrency(svc.precio)}</span>
+              <div>
+                <button
+                  className="btn btn-sm btn-warning me-2"
+                  onClick={() => handleEdit(svc)}
+                >
+                  Editar
+                </button>
+                <button
+                  className="btn btn-sm btn-danger"
+                  onClick={() => handleDelete(svc.id)}
+                >
+                  Eliminar
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default ServicesPanel;
+

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -1,0 +1,57 @@
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  doc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs
+} from 'firebase/firestore';
+import { db, auth } from './firebase';
+
+function getUidOrThrow() {
+  const uid = auth.currentUser?.uid;
+  if (!uid) {
+    throw new Error('No authenticated user');
+  }
+  return uid;
+}
+
+const getServicesCol = () => collection(db, 'users', getUidOrThrow(), 'services');
+
+export function subscribeServices(callback) {
+  const colRef = getServicesCol();
+  const unsubscribe = onSnapshot(colRef, (snapshot) => {
+    const data = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    callback(data);
+  });
+  return unsubscribe;
+}
+
+export async function addService(service) {
+  const docRef = await addDoc(getServicesCol(), service);
+  return { id: docRef.id, ...service };
+}
+
+export async function getService(id) {
+  const uid = getUidOrThrow();
+  const snap = await getDoc(doc(db, 'users', uid, 'services', id));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+export function updateService(id, data) {
+  const uid = getUidOrThrow();
+  return updateDoc(doc(db, 'users', uid, 'services', id), data);
+}
+
+export function deleteService(id) {
+  const uid = getUidOrThrow();
+  return deleteDoc(doc(db, 'users', uid, 'services', id));
+}
+
+export async function getAllServices() {
+  const snapshot = await getDocs(getServicesCol());
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+


### PR DESCRIPTION
## Summary
- add Firestore service collection with rules and helpers
- expose services via useServices and create management panel
- link services panel in navigation and app routes

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e1623b80832c90d93151f300c328