### PR TITLE
feat: track client info and history

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Login from "./pages/Login";
 import Finances from "./pages/Finances";
 import AddProducto from "./pages/AddProducto";
 import ServicesPanel from "./pages/ServicesPanel";
+import Clients from "./pages/Clients";
 
 import Navbar from "./components/Navbar";
 
@@ -57,6 +58,10 @@ function App() {
           <Route
             path="/servicios"
             element={<PrivateRoute user={currentUser}><ServicesPanel /></PrivateRoute>}
+          />
+          <Route
+            path="/clientes"
+            element={<PrivateRoute user={currentUser}><Clients /></PrivateRoute>}
           />
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -10,6 +10,7 @@ import {
   FaShoppingBag,
   FaSignOutAlt,
   FaCut,
+  FaUsers,
 } from 'react-icons/fa';
 
 function Navbar({ currentUser }) {
@@ -41,6 +42,9 @@ function Navbar({ currentUser }) {
         </Link>
         <Link to="/servicios" className="btn btn-nav nav-services">
           <FaCut className="me-1" /> Servicios
+        </Link>
+        <Link to="/clientes" className="btn btn-nav nav-clients">
+          <FaUsers className="me-1" /> Clientes
         </Link>
       </div>
       <div className="user-actions">

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -4,7 +4,8 @@ import React from 'react';
 
 function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, services = [] }) {
   // Desestructuramos todos los campos, incluido "precio" para el input numérico.
-  const { nombre, fecha, hora, servicio, precio } = turnoData;
+  // NUEVO: añadimos teléfono y notas al formulario de turnos.
+  const { nombre, telefono, notas, fecha, hora, servicio, precio } = turnoData;
 
   return (
     <>
@@ -19,6 +20,17 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, se
           value={nombre}
           onChange={onFormChange}
           required
+        />
+      </div>
+      <div className="mb-3">
+        <label htmlFor="telefono" className="form-label">Teléfono</label>
+        <input
+          type="tel"
+          className="form-control"
+          id="telefono"
+          name="telefono"
+          value={telefono}
+          onChange={onFormChange}
         />
       </div>
       <div className="mb-3">
@@ -75,6 +87,18 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, se
           value={precio}
           onChange={onFormChange}
           required
+        />
+      </div>
+
+      <div className="mb-3">
+        <label htmlFor="notas" className="form-label">Notas</label>
+        <textarea
+          className="form-control"
+          id="notas"
+          name="notas"
+          value={notas}
+          onChange={onFormChange}
+          rows={3}
         />
       </div>
 

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -11,6 +11,8 @@ import useServices from '../hooks/useServices';
 // Estado inicial: Ahora incluimos el servicio por defecto y el precio correspondiente
 const initialState = {
   nombre: '',
+  telefono: '',
+  notas: '',
   fecha: '',
   hora: '',
   servicio: '', // Servicio inicial vacío para obligar a la selección

--- a/src/pages/Clients.jsx
+++ b/src/pages/Clients.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { subscribeTurnos } from '../services/turnoService';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { formatCurrency } from '../utils/formatCurrency';
+
+function Clients() {
+  const [clients, setClients] = useState({});
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    try {
+      const unsubscribe = subscribeTurnos((data) => {
+        const grouped = data.reduce((acc, turno) => {
+          const key = turno.nombre || 'Sin nombre';
+          if (!acc[key]) acc[key] = [];
+          acc[key].push(turno);
+          return acc;
+        }, {});
+        Object.values(grouped).forEach((arr) =>
+          arr.sort((a, b) => {
+            const dateCompare = a.fecha.localeCompare(b.fecha);
+            if (dateCompare !== 0) return dateCompare;
+            return a.hora.localeCompare(b.hora);
+          })
+        );
+        setClients(grouped);
+      });
+      return () => unsubscribe();
+    } catch (err) {
+      console.error('Error al cargar clientes:', err);
+      if (err.message === 'No authenticated user') {
+        navigate('/login');
+      } else {
+        toast.error('Error al cargar clientes.');
+      }
+    }
+  }, [navigate]);
+
+  const clientEntries = Object.entries(clients);
+
+  return (
+    <div className="container mt-4">
+      <h2 className="mb-4">Clientes</h2>
+      {clientEntries.length === 0 && <p className="text-white-50">No hay turnos registrados.</p>}
+      {clientEntries.map(([nombre, turnos]) => {
+        const telefono = turnos[0].telefono;
+        return (
+          <div className="card mb-4" key={nombre}>
+            <div className="card-header">
+              <strong>{nombre}</strong>
+              {telefono && <span className="ms-2">- {telefono}</span>}
+            </div>
+            <ul className="list-group list-group-flush">
+              {turnos.map((t) => (
+                <li key={t.id} className="list-group-item">
+                  <div className="d-flex justify-content-between">
+                    <span>{t.fecha} {t.hora}</span>
+                    <span>{t.servicio} - {formatCurrency(t.precio)}</span>
+                  </div>
+                  {t.notas && <small className="text-muted d-block">{t.notas}</small>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default Clients;

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -24,6 +24,8 @@ function EditTurno() {
           setTurno({
             id: turnoDoc.id,
             nombre: data.nombre || '',
+            telefono: data.telefono || '',
+            notas: data.notas || '',
             fecha: data.fecha || '',
             hora: data.hora || '',
             servicio: data.servicio || '',

--- a/src/services/turnoService.js
+++ b/src/services/turnoService.js
@@ -38,8 +38,19 @@ export async function addTurno(turno) {
   if (existing) {
     throw new Error('Turno duplicado');
   }
-  const docRef = await addDoc(getTurnosCol(), turno);
-  return { id: docRef.id, ...turno };
+  // Solo almacenamos los campos esperados, incluyendo teléfono y notas.
+  const data = {
+    nombre: turno.nombre,
+    telefono: turno.telefono || '',
+    notas: turno.notas || '',
+    fecha: turno.fecha,
+    hora: turno.hora,
+    servicio: turno.servicio,
+    precio: turno.precio,
+    ...(turno.creado && { creado: turno.creado }),
+  };
+  const docRef = await addDoc(getTurnosCol(), data);
+  return { id: docRef.id, ...data };
 }
 
 // Get turno by id
@@ -52,7 +63,18 @@ export async function getTurno(id) {
 // Update turno
 export function updateTurno(id, data) {
   const uid = getUidOrThrow();
-  return updateDoc(doc(db, 'users', uid, 'turnos', id), data);
+  // Incluimos teléfono y notas en la actualización.
+  const dataToUpdate = {
+    nombre: data.nombre,
+    telefono: data.telefono || '',
+    notas: data.notas || '',
+    fecha: data.fecha,
+    hora: data.hora,
+    servicio: data.servicio,
+    precio: data.precio,
+    ...(data.creado && { creado: data.creado }),
+  };
+  return updateDoc(doc(db, 'users', uid, 'turnos', id), dataToUpdate);
 }
 
 // Delete turno


### PR DESCRIPTION
## Summary
- add `telefono` and `notas` fields to appointment form and state
- persist new fields in `addTurno` and `updateTurno`
- create Clients page to browse appointment history by customer

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0ff4ecc8832c8874fb995a4622da