### PR TITLE
feat: make confirm dialog accessible

### DIFF
--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -1,26 +1,64 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 function ConfirmDialog({ show, message, onConfirm, onCancel, confirmText = 'Aceptar', cancelText = 'Cancelar' }) {
-  if (!show) return null;
+  const dialogRef = useRef(null);
+  const cancelButtonRef = useRef(null);
+  const lastFocusedRef = useRef(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (show) {
+      lastFocusedRef.current = document.activeElement;
+      if (!dialog.open) dialog.showModal();
+      cancelButtonRef.current?.focus();
+    } else if (dialog.open) {
+      dialog.close();
+      lastFocusedRef.current?.focus();
+    }
+  }, [show]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleCancel = (e) => {
+      e.preventDefault();
+      onCancel();
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, [onCancel]);
+
+  const handleClickOutside = (e) => {
+    if (e.target === dialogRef.current) {
+      onCancel();
+    }
+  };
 
   return (
-    <div className="modal fade show" style={{ display: 'block', backgroundColor: 'rgba(0,0,0,0.5)' }} role="dialog" aria-modal="true">
-      <div className="modal-dialog">
-        <div className="modal-content bg-dark text-white">
-          <div className="modal-body">
-            {message}
-          </div>
-          <div className="modal-footer">
-            <button type="button" className="btn btn-outline-light" onClick={onCancel}>
-              {cancelText}
-            </button>
-            <button type="button" className="btn btn-primary" onClick={onConfirm}>
-              {confirmText}
-            </button>
-          </div>
+    <dialog ref={dialogRef} onClick={handleClickOutside} className="modal" aria-modal="true">
+      <div className="modal-content bg-dark text-white">
+        <div className="modal-body">
+          {message}
+        </div>
+        <div className="modal-footer">
+          <button
+            type="button"
+            ref={cancelButtonRef}
+            className="btn btn-outline-light"
+            onClick={onCancel}
+          >
+            {cancelText}
+          </button>
+          <button type="button" className="btn btn-primary" onClick={onConfirm}>
+            {confirmText}
+          </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -219,3 +219,12 @@ body {
     align-items: center;
   }
 }
+dialog.modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## Summary
- refactor confirm dialog to use native `<dialog>` element
- add escape and outside click handlers to close dialog
- focus cancel button on open and restore focus to triggering element

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa26d9e0dc832cafafadb69847769b