### PR TITLE
Add reusable LoadingSpinner component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,18 +12,13 @@ import ServicesPanel from "./pages/ServicesPanel";
 import Clients from "./pages/Clients";
 
 import Navbar from "./components/Navbar";
+import LoadingSpinner from "./components/LoadingSpinner";
 
 import { onAuthStateChanged } from "./services/authService";
 
 function PrivateRoute({ user, children }) {
   if (user === undefined) {
-    return (
-      <div className="d-flex justify-content-center align-items-center" style={{ height: '80vh' }}>
-        <div className="spinner-border" role="status">
-          <span className="visually-hidden">Cargando...</span>
-        </div>
-      </div>
-    );
+    return <LoadingSpinner style={{ height: '80vh' }} />;
   }
   return user ? children : <Navigate to="/login" />;
 }

--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -1,0 +1,16 @@
+// src/components/LoadingSpinner.jsx
+
+import React from 'react';
+
+function LoadingSpinner({ color = 'primary', size, className = '', style = {} }) {
+  const spinnerStyle = size ? { width: size, height: size } : {};
+  return (
+    <div className={`d-flex justify-content-center align-items-center ${className}`} style={style}>
+      <div className={`spinner-border text-${color}`} role="status" style={spinnerStyle}>
+        <span className="visually-hidden">Cargando...</span>
+      </div>
+    </div>
+  );
+}
+
+export default LoadingSpinner;

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -6,6 +6,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
 import useServices from '../hooks/useServices';
+import LoadingSpinner from '../components/LoadingSpinner';
 
 function EditTurno() {
   const { id } = useParams();
@@ -107,7 +108,7 @@ function EditTurno() {
     }
   };
   
-  if (loading) return <div className="text-center mt-5"><div className="spinner-border text-primary"></div></div>;
+  if (loading) return <LoadingSpinner className="mt-5" />;
   if (!turno) return <div className="alert alert-danger text-center">No se encontró el turno.</div>;
 
   return (

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -5,6 +5,7 @@ import { subscribeTurnos } from '../services/turnoService';
 import { subscribeProductSales } from '../services/ventaService';
 import { formatCurrency } from '../utils/formatCurrency';
 import { useNavigate } from 'react-router-dom';
+import LoadingSpinner from '../components/LoadingSpinner';
 
 function parseYearMonth(fecha) {
     const date = new Date(fecha);
@@ -135,11 +136,7 @@ function Finances() {
     ];
 
     if (loadingTurnos || loadingProducts) {
-        return (
-            <div className="text-center mt-5">
-                <div className="spinner-border text-primary"></div>
-            </div>
-        );
+        return <LoadingSpinner className="mt-5" />;
     }
 
     return (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,6 +8,7 @@ import TurnoList from "../components/TurnoList";
 import toast from 'react-hot-toast';
 import { formatCurrency } from "../utils/formatCurrency";
 import ConfirmDialog from "../components/ConfirmDialog";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 function Home() {
   const [allTurnos, setAllTurnos] = useState([]);
@@ -149,7 +150,7 @@ function Home() {
     navigate(`/edit-turno/${id}`);
   };
 
-  if (loading) return <div className="text-center mt-5"><div className="spinner-border text-primary"></div></div>;
+  if (loading) return <LoadingSpinner className="mt-5" />;
 
   return (
     <div className="container mt-4">


### PR DESCRIPTION
## Summary
- create configurable LoadingSpinner component
- replace inline bootstrap spinners with reusable component

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa295aa634832c97d07c7de26feccf