### PR TITLE
Refactor ConfirmDialog to use React-controlled visibility

### DIFF
--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 function ConfirmDialog({ show, message, onConfirm, onCancel, confirmText = 'Aceptar', cancelText = 'Cancelar' }) {
   const dialogRef = useRef(null);
@@ -6,20 +7,16 @@ function ConfirmDialog({ show, message, onConfirm, onCancel, confirmText = 'Acep
   const lastFocusedRef = useRef(null);
 
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
     if (show) {
       lastFocusedRef.current = document.activeElement;
-      if (!dialog.open) dialog.showModal();
       cancelButtonRef.current?.focus();
-    } else if (dialog.open) {
-      dialog.close();
+    } else {
       lastFocusedRef.current?.focus();
     }
   }, [show]);
 
   useEffect(() => {
+    if (!show) return;
     const dialog = dialogRef.current;
     if (!dialog) return;
 
@@ -30,7 +27,7 @@ function ConfirmDialog({ show, message, onConfirm, onCancel, confirmText = 'Acep
 
     dialog.addEventListener('cancel', handleCancel);
     return () => dialog.removeEventListener('cancel', handleCancel);
-  }, [onCancel]);
+  }, [show, onCancel]);
 
   const handleClickOutside = (e) => {
     if (e.target === dialogRef.current) {
@@ -38,27 +35,32 @@ function ConfirmDialog({ show, message, onConfirm, onCancel, confirmText = 'Acep
     }
   };
 
-  return (
-    <dialog ref={dialogRef} onClick={handleClickOutside} className="modal" aria-modal="true">
-      <div className="modal-content bg-dark text-white">
-        <div className="modal-body">
-          {message}
+  if (!show) return null;
+
+  return createPortal(
+    (
+      <dialog ref={dialogRef} open onClick={handleClickOutside} className="modal" aria-modal="true">
+        <div className="modal-content bg-dark text-white">
+          <div className="modal-body">
+            {message}
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              ref={cancelButtonRef}
+              className="btn btn-outline-light"
+              onClick={onCancel}
+            >
+              {cancelText}
+            </button>
+            <button type="button" className="btn btn-primary" onClick={onConfirm}>
+              {confirmText}
+            </button>
+          </div>
         </div>
-        <div className="modal-footer">
-          <button
-            type="button"
-            ref={cancelButtonRef}
-            className="btn btn-outline-light"
-            onClick={onCancel}
-          >
-            {cancelText}
-          </button>
-          <button type="button" className="btn btn-primary" onClick={onConfirm}>
-            {confirmText}
-          </button>
-        </div>
-      </div>
-    </dialog>
+      </dialog>
+    ),
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary
- Render confirmation dialog only when `show` is true and rely on React for visibility
- Portal the dialog to `document.body` and keep cancel button focused for accessibility

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a82512c832c83c77b09c3beb4a1