### PR TITLE
refactor: use theme classes for dark mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
   }, []);
 
   return (
-    <div className="container-fluid px-3 py-4 bg-dark text-white min-vh-100 d-flex flex-column">
+    <div className="container-fluid px-3 py-4 theme-container min-vh-100 d-flex flex-column">
       {currentUser && <Navbar currentUser={currentUser} />}
 
       <main className="flex-grow-1 mt-3">

--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -40,7 +40,7 @@ function ConfirmDialog({ show, message, onConfirm, onCancel, confirmText = 'Acep
   return createPortal(
     (
       <dialog ref={dialogRef} open onClick={handleClickOutside} className="modal" aria-modal="true">
-        <div className="modal-content bg-dark text-white">
+        <div className="modal-content theme-card">
           <div className="modal-body">
             {message}
           </div>

--- a/src/components/TurnoList.jsx
+++ b/src/components/TurnoList.jsx
@@ -5,7 +5,7 @@ import TurnoCard from './TurnoCard';
 
 function TurnoList({ turnos, onEdit, onDelete }) {
   if (turnos.length === 0) {
-    return <p className="text-white-50 text-center mt-4">No hay turnos registrados para este día.</p>;
+    return <p className="text-secondary text-center mt-4">No hay turnos registrados para este día.</p>;
   }
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -42,10 +42,32 @@ body {
   min-height: 100vh;
 }
 
+/* Theme utility classes */
+.theme-container {
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+}
+
+.theme-card {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+}
+
+.theme-select {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+}
+
+.text-secondary {
+  color: var(--color-text-secondary) !important;
+}
+
 /* 2. Estilos Generales */
-.form-control { 
-  background-color: var(--color-surface); 
-  color: var(--color-text-primary); 
+.form-control {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
   border-color: var(--color-border); 
 }
 .form-control:focus { 
@@ -226,15 +248,15 @@ body {
     margin-right: 0;
   }
   /* Ajuste para los selectores de Finanzas en móvil */
-  .card.bg-dark .d-flex.flex-wrap {
+  .card.theme-card .d-flex.flex-wrap {
       flex-direction: column;
       align-items: center;
   }
-  .card.bg-dark .form-label.me-2 {
+  .card.theme-card .form-label.me-2 {
       margin-right: 0 !important;
       margin-bottom: 5px !important;
   }
-  .card.bg-dark .form-select.w-auto {
+  .card.theme-card .form-select.w-auto {
       width: 80% !important; /* Más ancho para selectores en móvil */
       margin-bottom: 10px !important;
   }

--- a/src/pages/Clients.jsx
+++ b/src/pages/Clients.jsx
@@ -42,7 +42,7 @@ function Clients() {
   return (
     <div className="container mt-4">
       <h2 className="mb-4">Clientes</h2>
-      {clientEntries.length === 0 && <p className="text-white-50">No hay turnos registrados.</p>}
+      {clientEntries.length === 0 && <p className="text-secondary">No hay turnos registrados.</p>}
       {clientEntries.map(([nombre, turnos]) => {
         const telefono = turnos[0].telefono;
         return (

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -113,7 +113,7 @@ function EditTurno() {
 
   return (
     <div className="container mt-4" style={{ maxWidth: '600px' }}>
-      <div className="card bg-dark text-white p-4 shadow-sm" style={{ maxWidth: '500px', width: '100%' }}>
+      <div className="card theme-card p-4 shadow-sm" style={{ maxWidth: '500px', width: '100%' }}>
         <h2 className="mb-4 text-center">Editar Turno</h2>
         {turno && ( // Renderizamos el formulario solo si 'turno' no es null
           <TurnoForm

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -141,14 +141,14 @@ function Finances() {
 
     return (
         <div className="container mt-4" style={{ maxWidth: '800px' }}>
-            <h2 className="mb-4 text-white text-center">Resumen de Finanzas</h2>
+            <h2 className="mb-4 text-center">Resumen de Finanzas</h2>
 
-            <div className="card bg-dark text-white p-4 shadow-sm mb-4">
+            <div className="card theme-card p-4 shadow-sm mb-4">
                 <div className="d-flex flex-wrap justify-content-center align-items-center mb-3">
                     <label htmlFor="month-select" className="form-label me-2 mb-0">Mes:</label>
                     <select
                         id="month-select"
-                        className="form-select w-auto me-3 bg-secondary text-white border-0"
+                        className="form-select w-auto me-3 theme-select border-0"
                         value={selectedMonth}
                         onChange={(e) => setSelectedMonth(Number(e.target.value))}
                     >
@@ -160,7 +160,7 @@ function Finances() {
                     <label htmlFor="year-select" className="form-label me-2 mb-0">Año:</label>
                     <select
                         id="year-select"
-                        className="form-select w-auto me-3 bg-secondary text-white border-0"
+                        className="form-select w-auto me-3 theme-select border-0"
                         value={selectedYear}
                         onChange={(e) => setSelectedYear(Number(e.target.value))}
                     >
@@ -172,7 +172,7 @@ function Finances() {
                     <label htmlFor="category-select" className="form-label me-2 mb-0">Categoría:</label>
                     <select
                         id="category-select"
-                        className="form-select w-auto bg-secondary text-white border-0"
+                        className="form-select w-auto theme-select border-0"
                         value={selectedCategory}
                         onChange={(e) => setSelectedCategory(e.target.value)}
                     >
@@ -199,13 +199,13 @@ function Finances() {
                 </h4>
                 {/* FIN NUEVO */}
 
-                <p className="text-center text-white-50">
+                <p className="text-center text-secondary">
                     Calculado a partir de los turnos con precio y las ventas de productos en el mes seleccionado.
                 </p>
                 
                 {turnosDelMesFiltrados.length > 0 && (
                     <div className="mt-4 table-responsive">
-                        <h4 className="text-white-50 mb-3">Detalle de Turnos del Mes:</h4>
+                        <h4 className="text-secondary mb-3">Detalle de Turnos del Mes:</h4>
                         <table className="table table-dark table-striped table-hover">
                             <thead>
                                 <tr>
@@ -231,12 +231,12 @@ function Finances() {
                     </div>
                 )}
                 {turnosDelMesFiltrados.length === 0 && (
-                    <p className="text-white-50 text-center mt-3">No hay turnos con precio para este mes.</p>
+                    <p className="text-secondary text-center mt-3">No hay turnos con precio para este mes.</p>
                 )}
 
                 {ventasDelMesFiltradas.length > 0 && (
                     <div className="mt-4 table-responsive">
-                        <h4 className="text-white-50 mb-3">Detalle de Ventas de Productos del Mes:</h4>
+                        <h4 className="text-secondary mb-3">Detalle de Ventas de Productos del Mes:</h4>
                         <table className="table table-dark table-striped table-hover">
                             <thead>
                                 <tr>
@@ -264,7 +264,7 @@ function Finances() {
                     </div>
                 )}
                 {ventasDelMesFiltradas.length === 0 && (
-                    <p className="text-white-50 text-center mt-3">No hay ventas de productos para este mes.</p>
+                    <p className="text-secondary text-center mt-3">No hay ventas de productos para este mes.</p>
                 )}
 
             </div>
@@ -273,3 +273,4 @@ function Finances() {
 }
 
 export default Finances;
+

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -163,8 +163,8 @@ function Home() {
       )}
       {/* FIN NUEVO */}
 
-      <h2 className="mb-3 text-white">Tu Agenda</h2>
-      <div className="text-white mb-3">
+      <h2 className="mb-3">Tu Agenda</h2>
+      <div className="mb-3">
         Cortes completados: {cortesCompletados.length} — Ganancia: {formatCurrency(gananciaDiaria)}
       </div>
       <CalendarView
@@ -172,7 +172,7 @@ function Home() {
         selectedDate={selectedDate}
         turnos={allTurnos}
       />
-      <h3 className="mb-3 mt-4 text-white">
+      <h3 className="mb-3 mt-4">
         {selectedDate && `Turnos para el ${selectedDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}`}
       </h3>
       <TurnoList

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -38,7 +38,7 @@ function Login() {
 
   return (
     <div className="container mt-5 d-flex justify-content-center">
-      <div className="card bg-dark text-white p-4 shadow" style={{ maxWidth: '400px', width: '100%' }}>
+      <div className="card theme-card p-4 shadow" style={{ maxWidth: '400px', width: '100%' }}>
         <h2 className="card-title text-center mb-4">Iniciar Sesión</h2>
         <form onSubmit={handleLogin}>
           <div className="mb-3">


### PR DESCRIPTION
## Summary
- add theme utility classes using CSS variables for background and text colors
- replace hardcoded `bg-dark`/`text-white` classes with new theme classes across pages
- swap `text-white-50` helper classes for variable-based `text-secondary`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68aa3b0dd374832c835e3d9e23e99d2f