### PR TITLE
Handle delete errors and allow deletions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,19 +16,19 @@ service cloud.firestore {
 
       // Turnos subcollection per user
       match /turnos/{turnoId} {
-        allow read, write: if request.auth != null &&
+        allow read, create, update, delete: if request.auth != null &&
           (request.auth.uid == userId || request.auth.token.role == 'admin');
       }
 
       // Ventas de productos subcollection per user
       match /ventasProductos/{ventaId} {
-        allow read, write: if request.auth != null &&
+        allow read, create, update, delete: if request.auth != null &&
           (request.auth.uid == userId || request.auth.token.role == 'admin');
       }
 
       // Services subcollection per user
       match /services/{serviceId} {
-        allow read, write: if request.auth != null &&
+        allow read, create, update, delete: if request.auth != null &&
           (request.auth.uid == userId || request.auth.token.role == 'admin');
       }
     }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -121,25 +121,24 @@ function Home() {
     setConfirmState({ show: true, id });
   };
 
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
     const { id } = confirmState;
     if (notificationTimeouts.current[id]) {
       clearTimeout(notificationTimeouts.current[id]);
       delete notificationTimeouts.current[id];
     }
     setConfirmState({ show: false, id: null });
-    toast.promise(deleteTurno(id), {
-      loading: 'Eliminando turno...',
-      success: 'Turno eliminado con éxito',
-      error: (err) => {
-        console.error("Error al eliminar:", err);
-        if (err.message === 'No authenticated user') {
-          navigate('/login');
-          return 'Sesión expirada';
-        }
-        return 'No se pudo eliminar el turno.';
+    const toastId = toast.loading('Eliminando turno...');
+    try {
+      await deleteTurno(id);
+      toast.success('Turno eliminado con éxito', { id: toastId });
+    } catch (err) {
+      console.error("Error al eliminar:", err);
+      if (err.message === 'No authenticated user') {
+        navigate('/login');
       }
-    });
+      toast.error(err.code || err.message || 'No se pudo eliminar el turno.', { id: toastId });
+    }
   };
 
   const cancelDelete = () => {


### PR DESCRIPTION
## Summary
- show deletion errors to the user in Home page
- allow authenticated users to delete their data in Firestore rules

## Testing
- `npm test` *(fails: vitest not found; dependencies not installed)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7577bb68832c9e5132dd9fbecdb3