### PR TITLE
feat: mostrar servicio en tarjeta de turno

### DIFF
--- a/src/components/TurnoCard.jsx
+++ b/src/components/TurnoCard.jsx
@@ -4,14 +4,14 @@ import React from 'react';
 import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 
 function TurnoCard({ turno, onDelete, onEdit }) {
-  const { id, nombre, hora, servicio } = turno; // Mantenemos servicio aquí por si lo usamos en el 'title'
+  const { id, nombre, hora, servicio } = turno;
 
   return (
     <div className="turno-row">
       <div className="col-hora">{hora}</div>
-      {/* Añadimos un 'title' para poder ver el servicio al pasar el ratón */}
-      <div className="col-nombre" title={`Servicio: ${servicio || 'N/A'}`}>
-        {nombre}
+      <div className="col-nombre">
+        <span className="turno-nombre">{nombre}</span>
+        <small className="turno-servicio">{servicio || 'N/A'}</small>
       </div>
       <div className="col-acciones">
         <button

--- a/src/index.css
+++ b/src/index.css
@@ -233,9 +233,20 @@ body {
   flex: 1; /* Ocupa todo el espacio sobrante */
   min-width: 0;
   padding: 0 15px;
+  overflow: hidden;
+}
+
+.col-nombre .turno-nombre {
+  display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.col-nombre .turno-servicio {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
 }
 .col-acciones {
   flex: 0 0 110px; /* Ancho fijo para los botones */


### PR DESCRIPTION
## Summary
- mostrar debajo del nombre el servicio del turno
- ajustar estilos para servicio en tema oscuro

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab798fb390832c921cbd87012b4563