### PR TITLE
Make turn list columns responsive

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -226,7 +226,7 @@ body {
   border-top: 1px solid var(--color-border);
 }
 .col-hora {
-  flex: 0 0 100px; /* Ancho fijo para la hora */
+  flex: 0 0 20%; /* Ancho proporcional para la hora */
   text-align: center;
 }
 .col-nombre {
@@ -249,10 +249,20 @@ body {
   color: var(--color-text-secondary);
 }
 .col-acciones {
-  flex: 0 0 110px; /* Ancho fijo para los botones */
+  flex: 0 0 25%; /* Ancho proporcional para los botones */
   display: flex;
   justify-content: center;
   gap: 10px;
+}
+
+@media (max-width: 575.98px) {
+  .col-hora {
+    flex: 0 0 18%;
+  }
+  .col-acciones {
+    flex: 0 0 30%;
+    gap: 5px;
+  }
 }
 
 /* 7. Estilos Específicos para Selectores (Finanzas y TurnoForm) */


### PR DESCRIPTION
## Summary
- Use percentage widths for `.col-hora` and `.col-acciones`
- Add media query for screens <576px to shrink hour and action columns

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7b1ce35c832c84d93941861624ec