### PR TITLE
chore: expand action buttons

### DIFF
--- a/src/components/TurnoCard.jsx
+++ b/src/components/TurnoCard.jsx
@@ -18,7 +18,7 @@ function TurnoCard({ turno, onDelete, onEdit }) {
           type="button"
           aria-label="Editar turno"
           onClick={() => onEdit(id)}
-          className="btn btn-sm btn-edit"
+          className="btn btn-action btn-edit"
         >
           <FaEdit />
         </button>
@@ -26,7 +26,7 @@ function TurnoCard({ turno, onDelete, onEdit }) {
           type="button"
           aria-label="Eliminar turno"
           onClick={() => onDelete(id)}
-          className="btn btn-sm btn-delete"
+          className="btn btn-action btn-delete"
         >
           <FaTrashAlt />
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -167,6 +167,7 @@ body {
 .btn-edit:hover { color: var(--color-text-on-accent); background-color: var(--color-edit); border-color: var(--color-edit); }
 .btn-delete { color: var(--color-delete); border-color: var(--color-delete); }
 .btn-delete:hover { color: var(--color-text-on-accent); background-color: var(--color-delete); border-color: var(--color-delete); }
+.btn-action { padding: 0.75rem; font-size: 1.25rem; }
 .btn-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; border-radius: 0.2rem; }
 
 /* Botones de navegación unificados */


### PR DESCRIPTION
## Summary
- replace small buttons with `.btn-action` and expand touch area
- add `.btn-action` styles for larger padding and font size

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7e777288832c88cd1965069fb2ef